### PR TITLE
Don't chomp nextContext in componentWillReceiveProps.

### DIFF
--- a/src/strictPropTypes.js
+++ b/src/strictPropTypes.js
@@ -40,15 +40,15 @@ export default (Component, userConfiguration) => {
             this.validateProps(this.props);
 
             if (super.componentWillMount) {
-                super.componentWillMount();
+                super.componentWillMount(...arguments);
             }
         }
 
-        componentWillReceiveProps (nextProps) {
+        componentWillReceiveProps (nextProps, nextContext) {
             this.validateProps(nextProps);
 
             if (super.componentWillReceiveProps) {
-                super.componentWillReceiveProps(nextProps);
+                super.componentWillReceiveProps(nextProps, nextContext);
             }
         }
     };


### PR DESCRIPTION
React's poor documentation for context is probably to blame here

When a component defines 'contextTypes', componentWillReceiveProps also receives a nextContext parameter, which is otherwise null.

Without this patch, components that implement both context and componentWillReceiveProps stop receiving that extra parameter when strictPropTypes is in use.
